### PR TITLE
fixes to run using dart 2.1.0-dev 

### DIFF
--- a/lib/src/sanitizer.dart
+++ b/lib/src/sanitizer.dart
@@ -27,7 +27,7 @@ double toFloat(String str) {
   try{
     return double.parse(str);
   } catch (e) {
-    return double.NAN;
+    return double.nan;
   }
 }
 
@@ -45,7 +45,7 @@ num toInt(String str, {int radix:10}) {
     try {
       return double.parse(str).toInt();
     } catch (e) {
-      return double.NAN;
+      return double.nan;
     }
   }
 }

--- a/lib/src/validator.dart
+++ b/lib/src/validator.dart
@@ -481,7 +481,7 @@ bool isISBN(String str, [version]) {
 /// check if the string is valid JSON
 bool isJSON(str) {
   try {
-    JSON.decode(str);
+    json.decode(str);
   } catch (e) {
     return false;
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: validator
-version: 0.0.9
+version: 0.0.10
 author: Karan Goel <karan@goel.io>
 description: String validation and sanitization for Dart.
 homepage: https://github.com/karan/validator.dart

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,8 +1,10 @@
 name: validator
-version: 0.0.7
+version: 0.0.8
 author: Karan Goel <karan@goel.io>
 description: String validation and sanitization for Dart.
 homepage: https://github.com/karan/validator.dart
+environment:
+  sdk: '>=1.20.1'
 documentation: https://github.com/karan/validator.dart
 dependencies:
   unittest: any

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: validator
-version: 0.0.8
+version: 0.0.9
 author: Karan Goel <karan@goel.io>
 description: String validation and sanitization for Dart.
 homepage: https://github.com/karan/validator.dart

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,4 +7,4 @@ environment:
   sdk: '>=1.20.1 <=2.1.0'
 documentation: https://github.com/karan/validator.dart
 dependencies:
-  unittest: any
+  test: any

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ author: Karan Goel <karan@goel.io>
 description: String validation and sanitization for Dart.
 homepage: https://github.com/karan/validator.dart
 environment:
-  sdk: '>=1.20.1'
+  sdk: '>=1.20.1 <=2.1.0'
 documentation: https://github.com/karan/validator.dart
 dependencies:
   unittest: any


### PR DESCRIPTION
(Related to #6)

Few days ago, Dart version updated from `2.0.x`to `2.1.0-dev`.

This major updated broke a huge list of dart packages (do a google search and I'll see). 

Dart is strict restrictive about version. If you not declare environment `sdk` in `pubspec.yaml`, Dart will assume `2.0` by default.

I updated `pubspec.yaml` to fix that and changed dependency package, since `unittest` is deprecated and the author recommends to use `test` instead.

I hope it's okay for you.

Thanks!

PS: If you accept my pul request, pls update package in pub.dartlang.org too.